### PR TITLE
eval: wire eval_tta.py into Makefile and document on Aria-MPS gold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PYTHON     ?= python
 
 .PHONY: help eval-wilor-pov eval-hamer-pov eval-handoccnet-pov eval-mgfm-pov \
         eval-wilor-aria eval-hamer-aria eval-handoccnet-aria eval-mgfm-aria \
-        eval-ensemble eval-per-seq eval-per-finger \
+        eval-ensemble eval-per-seq eval-per-finger eval-tta \
         ft-wilor-pov ft-wilor-mixed ft-wilor-anchored ft-wilor-distill ft-honet \
         precompute-teacher viz-mesh viz-kpts viz-export
 
@@ -25,6 +25,7 @@ help:
 	@echo "  eval-ensemble                                   weighted MGFM+HONet"
 	@echo "  eval-per-seq                                    per-sequence breakdown"
 	@echo "  eval-per-finger                                 per-finger PA-MPJPE"
+	@echo "  eval-tta                                        test-time adaptation on Aria-MPS gold"
 	@echo "  ft-wilor-pov                                    Exp A (POV-only)"
 	@echo "  ft-wilor-mixed                                  Exp B (POV + Aria HSAM)"
 	@echo "  ft-wilor-anchored                               Exp B+ (mesh anchor)"
@@ -78,6 +79,10 @@ eval-per-seq:
 eval-per-finger:
 	$(PYTHON) -m src.eval.per_finger_eval --data $(DATA) --ckpt $(CKPT) \
 	    --out $(RESULTS)/per_finger.json
+
+eval-tta:
+	$(PYTHON) -m src.eval.eval_tta --data $(DATA) --ckpt $(CKPT) \
+	    --out $(RESULTS)/tta_aria_mps.json
 
 # --- training ---------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Every row in the headline table maps to one or two `Makefile` targets.
 | Off-shelf benchmark                             | `eval-{wilor,hamer,handoccnet,mgfm}-{pov,aria}`    | ~30 min total      |
 | Per-sequence Aria breakdown                     | `eval-per-seq`                                     | ~10 min            |
 | Per-finger PA-MPJPE                             | `eval-per-finger`                                  | ~5 min             |
+| Test-time adaptation on Aria-MPS gold           | `eval-tta`                                         | ~25 min            |
 | Exp A (POV-only FT)                             | `ft-wilor-pov` then `eval-wilor-{pov,aria}`        | ~3 h               |
 | **Exp B (mixed FT, headline)**                  | `ft-wilor-mixed` then `eval-wilor-{pov,aria}`      | ~3 h               |
 | Exp B+ (anchored regularizer)                   | `ft-wilor-anchored`                                | ~3 h               |
@@ -142,6 +143,17 @@ Smoke test (should print PA-MPJPE around 11 mm):
 ```bash
 make eval-wilor-pov DATA=data CKPT=checkpoints RESULTS=results
 ```
+
+## Test-time adaptation
+
+`make eval-tta` runs `src/eval/eval_tta.py`, which evaluates the
+ensemble (MGFM + HONet) on Aria-MPS gold with horizontal-flip TTA: each
+crop is predicted twice, the flipped prediction is unflipped, and the
+two are averaged in 3D. No parameter updates; this is inference-only
+TTA. Output is written to `results/tta_aria_mps.json`.
+
+Use this to probe the Aria HSAM (9.00 mm) vs Aria-MPS gold (41.67 mm)
+gap reported for WiLoR FT mixed without retraining the model.
 
 ## Path overrides
 


### PR DESCRIPTION
Closes #19

Wires the existing horizontal-flip TTA evaluator into the reproducibility surface.

Changes
- Makefile: adds `eval-tta` target and entry in `make help`.
- README.md: adds row for eval-tta in the reproduction map; adds a short
  "Test-time adaptation" section describing the flip-only procedure
  (no parameter updates) and pointing at the Aria HSAM vs Aria-MPS gold
  gap as motivation.

eval_tta.py itself is unchanged.