### PR TITLE
train: wire ft_wilor_distill_v2 into Makefile and document Exp I-v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ PYTHON     ?= python
 .PHONY: help eval-wilor-pov eval-hamer-pov eval-handoccnet-pov eval-mgfm-pov \
         eval-wilor-aria eval-hamer-aria eval-handoccnet-aria eval-mgfm-aria \
         eval-ensemble eval-per-seq eval-per-finger eval-tta \
-        ft-wilor-pov ft-wilor-mixed ft-wilor-anchored ft-wilor-distill ft-honet \
+        ft-wilor-pov ft-wilor-mixed ft-wilor-anchored ft-wilor-distill \
+        ft-wilor-distill-v2 ft-honet \
         precompute-teacher viz-mesh viz-kpts viz-export
 
 help:
@@ -30,6 +31,7 @@ help:
 	@echo "  ft-wilor-mixed                                  Exp B (POV + Aria HSAM)"
 	@echo "  ft-wilor-anchored                               Exp B+ (mesh anchor)"
 	@echo "  ft-wilor-distill                                Exp I  (MGFM+HONet -> WiLoR)"
+	@echo "  ft-wilor-distill-v2                             Exp I-v2 (multi-teacher + mesh anchor)"
 	@echo "  ft-honet                                        HandOccNet FT (Exp E/F)"
 	@echo "  precompute-teacher                              cache MGFM+HONet on Aria train"
 	@echo "  viz-{mesh,kpts,export}                          rendering helpers"
@@ -102,6 +104,12 @@ ft-wilor-distill: precompute-teacher
 	$(PYTHON) -m src.train.ft_wilor_distill --data $(DATA) --ckpt $(CKPT)/wilor \
 	    --teacher_cache $(RESULTS)/teacher_cache.npz \
 	    --out $(CKPT)/wilor_ft_distill
+
+ft-wilor-distill-v2: precompute-teacher
+	$(PYTHON) -m src.train.ft_wilor_distill_v2 --data $(DATA) --ckpt $(CKPT)/wilor \
+	    --teacher_cache $(RESULTS)/teacher_cache.npz \
+	    --lambda_mesh 0.5 \
+	    --out $(CKPT)/wilor_ft_distill_v2
 
 ft-honet:
 	$(PYTHON) -m src.train.ft_honet --data $(DATA) --ckpt $(CKPT)/handoccnet \

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Every row in the headline table maps to one or two `Makefile` targets.
 | Exp E/F (HandOccNet FT, expected to regress)    | `ft-honet`                                         | ~2 h               |
 | Inference-time ensemble                         | `eval-ensemble`                                    | ~20 min            |
 | **Exp I (multi-teacher distillation)**          | `precompute-teacher` then `ft-wilor-distill`       | ~6 h               |
+| Exp I-v2 (distill + mesh-anchor regularizer)    | `precompute-teacher` then `ft-wilor-distill-v2`    | ~6 h               |
 
 Smoke test (should print PA-MPJPE around 11 mm):
 
@@ -173,6 +174,18 @@ export AIM2_CACHE_DIR=/path/to/cache
 ```
 
 Python scripts also accept `--data`, `--ckpt`, `--out` flags directly.
+
+## Distillation gap analysis
+
+The inference ensemble (0.75 MGFM + 0.25 HONet) reaches 11.52 mm on
+Aria-MPS gold, but the Exp I student WiLoR only reaches 27.87 mm, a
+2.4x gap. Exp I-v2 (`ft-wilor-distill-v2`) is the second iteration:
+it keeps the multi-teacher supervision from Exp I but adds the
+mesh-shape preservation regularizer from Exp B+ (lambda_mesh = 0.5)
+to discourage MANO-pose drift toward unnatural mesh configurations
+that score well on PA-MPJPE but render badly. Run via
+`make ft-wilor-distill-v2` then `make eval-wilor-aria` against
+`$(CKPT)/wilor_ft_distill_v2`.
 
 ## Reproducibility notes
 


### PR DESCRIPTION
Closes #21

Wires the existing distill-v2 trainer into the reproducibility surface
and documents how it differs from Exp I.

Changes
- Makefile: adds `ft-wilor-distill-v2` target (depends on
  `precompute-teacher`, passes `--lambda_mesh 0.5`) and entry in
  `make help`.
- README.md: adds Exp I-v2 row in the reproduction map; adds a
  "Distillation gap analysis" section that motivates v2 (keep
  multi-teacher supervision, add mesh-shape regularizer to
  discourage MANO-pose drift).

ft_wilor_distill_v2.py itself is unchanged.